### PR TITLE
Add import of new groups from keycloak

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Usage of ./appuio-keycloak-adapter:
       The address of the Keycloak server (E.g. https://keycloak.example.com).
   -keycloak-username string
       The username to log in to the Keycloak server.
+
+  -sync-schedule string
+      A cron style schedule for the organization synchronization interval. (default "@every 5m")
+  -sync-timeout duration
+      The timeout for a single synchronization run. (default 10s)
 ```
 
 ### Authenticating to Keycloak
@@ -38,6 +43,13 @@ The following permissions must be associated to the user:
 
 * Password must be set (Temporary option unselected) on the _Credentials_ tab
 * On the _Role Mappings_ tab, select _realm-management_ next to the _Client Roles_ dropdown and then select **query-users**, **manage-users**, and **query-groups**.
+
+
+### Organization Import
+
+Apart from mirroring changes on `Organization` resources to Keycloak, this component will also periodically import any top-level Keycloak group as `Organizations`
+It will however only create `Organization` resources and will never update them.
+This import schedule is configured through the `sync-schedule` flag.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The following permissions must be associated to the user:
 
 ### Organization Import
 
-Apart from mirroring changes on `Organization` resources to Keycloak, this component will also periodically import any top-level Keycloak group as `Organizations`
+In addition to mirroring changes on `Organization` resources to Keycloak, this component will also periodically import any top-level Keycloak group as `Organizations`
 It will however only create `Organization` resources and will never update them.
 This import schedule is configured through the `sync-schedule` flag.
 

--- a/controllers/ZZ_mock_keycloak_test.go
+++ b/controllers/ZZ_mock_keycloak_test.go
@@ -49,6 +49,21 @@ func (mr *MockKeycloakClientMockRecorder) DeleteGroup(ctx, groupName interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteGroup", reflect.TypeOf((*MockKeycloakClient)(nil).DeleteGroup), ctx, groupName)
 }
 
+// ListGroups mocks base method.
+func (m *MockKeycloakClient) ListGroups(ctx context.Context) ([]keycloak.Group, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListGroups", ctx)
+	ret0, _ := ret[0].([]keycloak.Group)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListGroups indicates an expected call of ListGroups.
+func (mr *MockKeycloakClientMockRecorder) ListGroups(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroups", reflect.TypeOf((*MockKeycloakClient)(nil).ListGroups), ctx)
+}
+
 // PutGroup mocks base method.
 func (m *MockKeycloakClient) PutGroup(ctx context.Context, group keycloak.Group) (keycloak.Group, error) {
 	m.ctrl.T.Helper()

--- a/controllers/organization_controller.go
+++ b/controllers/organization_controller.go
@@ -28,6 +28,7 @@ type OrganizationReconciler struct {
 type KeycloakClient interface {
 	PutGroup(ctx context.Context, group keycloak.Group) (keycloak.Group, error)
 	DeleteGroup(ctx context.Context, groupName string) error
+	ListGroups(ctx context.Context) ([]keycloak.Group, error)
 }
 
 var orgFinalizer = "keycloak-adapter.vshn.net/finalizer"

--- a/controllers/organization_controller.go
+++ b/controllers/organization_controller.go
@@ -51,6 +51,12 @@ func (r *OrganizationReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	if org.Annotations[orgImportAnnot] == "true" {
+		// This organization is being imported.
+		// Skipping to avoid race condition
+		return ctrl.Result{}, nil
+	}
+
 	if !org.ObjectMeta.DeletionTimestamp.IsZero() {
 		log.V(4).Info("Deleting Keycloak group..")
 		err = r.Keycloak.DeleteGroup(ctx, org.Name)

--- a/controllers/organization_controller_sync.go
+++ b/controllers/organization_controller_sync.go
@@ -1,0 +1,77 @@
+package controllers
+
+import (
+	"context"
+
+	orgv1 "github.com/appuio/control-api/apis/organization/v1"
+	controlv1 "github.com/appuio/control-api/apis/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var orgImportAnnot = "keycloak-adapter.vshn.net/importing"
+
+func (r *OrganizationReconciler) Sync(ctx context.Context) error {
+	log := log.FromContext(ctx)
+
+	gs, err := r.Keycloak.ListGroups(ctx)
+	if err != nil {
+		log.Error(err, "error listing Keycloak groups")
+		return err
+	}
+	log.WithValues("groups", gs).Info("got groups")
+
+	orgs := orgv1.OrganizationList{}
+	err = r.List(ctx, &orgs)
+	if err != nil {
+		log.Error(err, "error listing organizations")
+		return err
+	}
+	log.WithValues("orgs", orgs).Info("got organizations")
+
+	orgMap := map[string]struct{}{}
+	for _, o := range orgs.Items {
+		orgMap[o.Name] = struct{}{}
+	}
+
+	for _, g := range gs {
+		if _, ok := orgMap[g.Name]; !ok {
+			log.WithValues("g", g).Info("creating org")
+			org := orgv1.Organization{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: g.Name,
+				},
+				Spec: orgv1.OrganizationSpec{
+					DisplayName: g.Name,
+				},
+			}
+			err := r.Create(ctx, &org)
+			if err != nil {
+				log.WithValues("org", org.Name).Error(err, "failed to create organization")
+				continue
+			}
+
+			orgMemb := controlv1.OrganizationMembers{}
+			err = r.Get(ctx, types.NamespacedName{
+				Namespace: org.Name,
+				Name:      "members",
+			}, &orgMemb)
+			if err != nil {
+				log.WithValues("org", org.Name).Error(err, "failed to get organization members")
+				continue
+			}
+			orgMemb.Spec.UserRefs = make([]controlv1.UserRef, len(g.Members))
+			for i, m := range g.Members {
+				orgMemb.Spec.UserRefs[i] = controlv1.UserRef{Name: m}
+			}
+			err = r.Update(ctx, &orgMemb)
+			if err != nil {
+				log.WithValues("org", org.Name).Error(err, "failed to update organization members")
+				continue
+			}
+		}
+	}
+	return nil
+}

--- a/controllers/organization_controller_sync.go
+++ b/controllers/organization_controller_sync.go
@@ -5,6 +5,7 @@ import (
 
 	orgv1 "github.com/appuio/control-api/apis/organization/v1"
 	controlv1 "github.com/appuio/control-api/apis/v1"
+	"github.com/vshn/appuio-keycloak-adapter/keycloak"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -13,6 +14,7 @@ import (
 
 var orgImportAnnot = "keycloak-adapter.vshn.net/importing"
 
+// Sync lists all Keycloak groups in the realm and creates corresponding Organizations if they do not exist
 func (r *OrganizationReconciler) Sync(ctx context.Context) error {
 	log := log.FromContext(ctx)
 
@@ -22,67 +24,87 @@ func (r *OrganizationReconciler) Sync(ctx context.Context) error {
 		return err
 	}
 
-	orgs := orgv1.OrganizationList{}
-	err = r.List(ctx, &orgs)
+	orgMap, err := r.getOrganiztionMap(ctx)
 	if err != nil {
-		log.Error(err, "error listing organizations")
+		log.Error(err, "error listing Organizations")
 		return err
-	}
-
-	orgMap := map[string]*orgv1.Organization{}
-	for i, o := range orgs.Items {
-		orgMap[o.Name] = &orgs.Items[i]
 	}
 
 	for _, g := range gs {
 		org, ok := orgMap[g.Name]
 		if !ok {
 			log.V(1).WithValues("group", g).Info("creating organization")
-			org = &orgv1.Organization{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: g.Name,
-					Annotations: map[string]string{
-						orgImportAnnot: "true",
-					},
-				},
-				Spec: orgv1.OrganizationSpec{
-					DisplayName: g.Name,
-				},
-			}
-			err := r.Create(ctx, org)
+			org, err = r.startImportOrganizationFromGroup(ctx, g)
 			if err != nil {
-				log.WithValues("org", org.Name).Error(err, "failed to create organization")
+				log.WithValues("group", g).Error(err, "failed to start organization import")
 				continue
 			}
 		}
 		if org.Annotations[orgImportAnnot] == "true" {
 			log.V(1).WithValues("group", g).Info("updating organization members")
-			orgMemb := controlv1.OrganizationMembers{}
-			err = r.Get(ctx, types.NamespacedName{
-				Namespace: g.Name,
-				Name:      "members",
-			}, &orgMemb)
+			err := r.updateOrganizationMembersFromGroup(ctx, g)
 			if err != nil {
-				log.WithValues("org", org.Name).Error(err, "failed to get organization members")
+				log.WithValues("group", g).Error(err, "failed to update organization members")
 				continue
 			}
-			orgMemb.Spec.UserRefs = make([]controlv1.UserRef, len(g.Members))
-			for i, m := range g.Members {
-				orgMemb.Spec.UserRefs[i] = controlv1.UserRef{Name: m}
-			}
-			err = r.Update(ctx, &orgMemb)
+			err = r.finishImportOrganizationFromGroup(ctx, org)
 			if err != nil {
-				log.WithValues("org", org.Name).Error(err, "failed to update organization members")
-				continue
-			}
-
-			delete(org.Annotations, orgImportAnnot)
-			err = r.Update(ctx, org)
-			if err != nil {
-				log.WithValues("org", org.Name).Error(err, "failed to update organization")
+				log.WithValues("group", g).Error(err, "failed to finish organization import")
 				continue
 			}
 		}
 	}
 	return nil
+}
+
+func (r *OrganizationReconciler) getOrganiztionMap(ctx context.Context) (map[string]*orgv1.Organization, error) {
+	orgs := orgv1.OrganizationList{}
+	err := r.List(ctx, &orgs)
+	if err != nil {
+		return nil, err
+	}
+
+	orgMap := map[string]*orgv1.Organization{}
+	for i, o := range orgs.Items {
+		orgMap[o.Name] = &orgs.Items[i]
+	}
+	return orgMap, nil
+}
+
+func (r *OrganizationReconciler) startImportOrganizationFromGroup(ctx context.Context, group keycloak.Group) (*orgv1.Organization, error) {
+	org := &orgv1.Organization{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: group.Name,
+			Annotations: map[string]string{
+				orgImportAnnot: "true",
+			},
+		},
+		Spec: orgv1.OrganizationSpec{
+			DisplayName: group.Name,
+		},
+	}
+	err := r.Create(ctx, org)
+	return org, err
+}
+
+func (r *OrganizationReconciler) finishImportOrganizationFromGroup(ctx context.Context, org *orgv1.Organization) error {
+	delete(org.Annotations, orgImportAnnot)
+	return r.Update(ctx, org)
+
+}
+
+func (r *OrganizationReconciler) updateOrganizationMembersFromGroup(ctx context.Context, group keycloak.Group) error {
+	orgMemb := controlv1.OrganizationMembers{}
+	err := r.Get(ctx, types.NamespacedName{
+		Namespace: group.Name,
+		Name:      "members",
+	}, &orgMemb)
+	if err != nil {
+		return err
+	}
+	orgMemb.Spec.UserRefs = make([]controlv1.UserRef, len(group.Members))
+	for i, m := range group.Members {
+		orgMemb.Spec.UserRefs[i] = controlv1.UserRef{Name: m}
+	}
+	return r.Update(ctx, &orgMemb)
 }

--- a/controllers/organization_controller_sync_test.go
+++ b/controllers/organization_controller_sync_test.go
@@ -1,0 +1,131 @@
+package controllers_test
+
+import (
+	"context"
+	"testing"
+
+	orgv1 "github.com/appuio/control-api/apis/organization/v1"
+	controlv1 "github.com/appuio/control-api/apis/v1"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vshn/appuio-keycloak-adapter/keycloak"
+
+	. "github.com/vshn/appuio-keycloak-adapter/controllers"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func Test_Sync_Success(t *testing.T) {
+	ctx := context.Background()
+
+	c, keyMock := prepareTest(t, fooOrg, fooMemb, &controlv1.OrganizationMembers{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "members",
+			Namespace: "bar",
+		},
+	}) // We need to add barMember manually as there is no control API in the tests creating them
+
+	groups := []keycloak.Group{
+		{Name: "bar", Members: []string{"bar", "bar3"}},
+	}
+	keyMock.EXPECT().
+		ListGroups(gomock.Any()).
+		Return(groups, nil).
+		Times(1)
+
+	err := (&OrganizationReconciler{
+		Client:   c,
+		Scheme:   &runtime.Scheme{},
+		Keycloak: keyMock,
+	}).Sync(ctx)
+	require.NoError(t, err)
+
+	newOrg := orgv1.Organization{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "bar"}, &newOrg))
+	assert.NotContains(t, newOrg.Annotations, "keycloak-adapter.vshn.net/importing")
+	newMemb := controlv1.OrganizationMembers{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "members", Namespace: "bar"}, &newMemb))
+	assert.ElementsMatch(t, []controlv1.UserRef{
+		{Name: "bar3"},
+		{Name: "bar"},
+	}, newMemb.Spec.UserRefs)
+
+}
+
+func Test_Sync_Fail_Update(t *testing.T) {
+	ctx := context.Background()
+
+	c, keyMock := prepareTest(t, fooOrg, &controlv1.OrganizationMembers{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "members",
+			Namespace: "bar",
+		},
+	})
+	// By not adding buzzMember manually we simulate an error while updating the members resource
+
+	groups := []keycloak.Group{
+		{Name: "buzz", Members: []string{"buzz1", "buzz"}},
+		{Name: "bar", Members: []string{"bar", "bar3"}},
+	}
+	keyMock.EXPECT().
+		ListGroups(gomock.Any()).
+		Return(groups, nil).
+		Times(1)
+
+	err := (&OrganizationReconciler{
+		Client:   c,
+		Scheme:   &runtime.Scheme{},
+		Keycloak: keyMock,
+	}).Sync(ctx)
+	assert.Error(t, err)
+
+	newOrg := orgv1.Organization{}
+	assert.NoError(t, c.Get(ctx, types.NamespacedName{Name: "bar"}, &newOrg))
+	assert.NotContains(t, newOrg.Annotations, "keycloak-adapter.vshn.net/importing")
+	newMemb := controlv1.OrganizationMembers{}
+	assert.Error(t, c.Get(ctx, types.NamespacedName{Name: "members", Namespace: "buzz"}, &newMemb))
+
+	assert.NoError(t, c.Get(ctx, types.NamespacedName{Name: "buzz"}, &newOrg))
+	assert.Equal(t, "true", newOrg.Annotations["keycloak-adapter.vshn.net/importing"])
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "members", Namespace: "bar"}, &newMemb))
+	assert.ElementsMatch(t, []controlv1.UserRef{
+		{Name: "bar3"},
+		{Name: "bar"},
+	}, newMemb.Spec.UserRefs)
+
+}
+
+func Test_Sync_Skip_Existing(t *testing.T) {
+	ctx := context.Background()
+
+	c, keyMock := prepareTest(t, fooOrg, fooMemb) // We need to add barMember manually as there is no control API in the tests creating them
+
+	groups := []keycloak.Group{
+		{Name: "foo", Members: []string{"foo", "foo2"}},
+	}
+	keyMock.EXPECT().
+		ListGroups(gomock.Any()).
+		Return(groups, nil).
+		Times(1)
+
+	err := (&OrganizationReconciler{
+		Client:   c,
+		Scheme:   &runtime.Scheme{},
+		Keycloak: keyMock,
+	}).Sync(ctx)
+	require.NoError(t, err)
+
+	newOrg := orgv1.Organization{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "foo"}, &newOrg))
+	assert.NotContains(t, newOrg.Annotations, "keycloak-adapter.vshn.net/importing")
+	newMemb := controlv1.OrganizationMembers{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "members", Namespace: "foo"}, &newMemb))
+	assert.ElementsMatch(t, []controlv1.UserRef{
+		{Name: "bar3"},
+		{Name: "bar"},
+	}, newMemb.Spec.UserRefs)
+
+}

--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,7 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.28.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/segmentio/ksuid v1.0.4 // indirect
 	github.com/spf13/cobra v1.2.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -758,6 +758,8 @@ github.com/quasilyte/regex/syntax v0.0.0-20200407221936-30656e2c4a95/go.mod h1:r
 github.com/rancher/kine v0.4.0/go.mod h1:IImtCJ68AIkE+VY/kUI0NkyJL5q5WzO8QvMsSXqbrpA=
 github.com/rancher/wrangler v0.4.0/go.mod h1:1cR91WLhZgkZ+U4fV9nVuXqKurWbgXcIReU4wnQvTN8=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/keycloak/client.go
+++ b/keycloak/client.go
@@ -113,6 +113,36 @@ func (c Client) DeleteGroup(ctx context.Context, groupName string) error {
 	return c.Client.DeleteGroup(ctx, token.AccessToken, c.Realm, *found.ID)
 }
 
+// ListGroups returns all Keycloak groups in the realm.
+// This is potentially very expensive, as it needs to iterate over all groups to get its members.
+func (c Client) ListGroups(ctx context.Context) ([]Group, error) {
+	token, err := c.Client.LoginAdmin(ctx, c.Username, c.Password, c.Realm)
+	if err != nil {
+		return nil, fmt.Errorf("failed binding to keycloak: %w", err)
+	}
+
+	groups, err := c.Client.GetGroups(ctx, token.AccessToken, c.Realm, gocloak.GetGroupsParams{})
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]Group, len(groups))
+
+	for i, g := range groups {
+		res[i].Name = *g.Name
+		memb, err := c.Client.GetGroupMembers(ctx, token.AccessToken, c.Realm, *g.ID, gocloak.GetGroupsParams{})
+		if err != nil {
+			return res, fmt.Errorf("failed finding groupmembers for group %s: %w", *g.Name, err)
+		}
+    res[i].Members = make([]string, len(memb))
+    for j, m := range memb {
+      res[i].Members[j] = *m.Username
+    }
+	}
+
+	return res, nil
+}
+
 func (c Client) getGroupByName(ctx context.Context, token *gocloak.JWT, name string) (*gocloak.Group, error) {
 	// This may return more than one 1 result
 	groups, err := c.Client.GetGroups(ctx, token.AccessToken, c.Realm, gocloak.GetGroupsParams{

--- a/keycloak/client.go
+++ b/keycloak/client.go
@@ -134,10 +134,10 @@ func (c Client) ListGroups(ctx context.Context) ([]Group, error) {
 		if err != nil {
 			return res, fmt.Errorf("failed finding groupmembers for group %s: %w", *g.Name, err)
 		}
-    res[i].Members = make([]string, len(memb))
-    for j, m := range memb {
-      res[i].Members[j] = *m.Username
-    }
+		res[i].Members = make([]string, len(memb))
+		for j, m := range memb {
+			res[i].Members[j] = *m.Username
+		}
 	}
 
 	return res, nil

--- a/keycloak/client.go
+++ b/keycloak/client.go
@@ -114,7 +114,7 @@ func (c Client) DeleteGroup(ctx context.Context, groupName string) error {
 }
 
 // ListGroups returns all Keycloak groups in the realm.
-// This is potentially very expensive, as it needs to iterate over all groups to get its members.
+// This is potentially very expensive, as it needs to iterate over all groups to get their members.
 func (c Client) ListGroups(ctx context.Context) ([]Group, error) {
 	token, err := c.Client.LoginAdmin(ctx, c.Username, c.Password, c.Realm)
 	if err != nil {

--- a/keycloak/client_list_test.go
+++ b/keycloak/client_list_test.go
@@ -1,0 +1,64 @@
+package keycloak_test
+
+import (
+	context "context"
+	"fmt"
+
+	"testing"
+
+	gocloak "github.com/Nerzal/gocloak/v10"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	. "github.com/vshn/appuio-keycloak-adapter/keycloak"
+
+	gomock "github.com/golang/mock/gomock"
+)
+
+func TestListGroups_simple(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mKeycloak := NewMockGoCloak(ctrl)
+	c := Client{
+		Client:   mKeycloak,
+		Realm:    "foo",
+		Username: "bar",
+		Password: "buzz",
+	}
+
+	gs := []*gocloak.Group{
+		{
+			ID:   gocloak.StringP("foo-id"),
+			Name: gocloak.StringP("foo-gmbh"),
+		},
+		{
+			ID:   gocloak.StringP("bar-id"),
+			Name: gocloak.StringP("bar-gmbh"),
+		},
+		{
+			ID:   gocloak.StringP("buzz-id"),
+			Name: gocloak.StringP("buzz-gmbh"),
+		},
+	}
+	mockLogin(mKeycloak, c)
+	mockListGroups(mKeycloak, c, gs)
+	for i := range gs {
+		us := []*gocloak.User{}
+		for j := 0; j < i; j++ {
+			us = append(us, &gocloak.User{
+				ID:       gocloak.StringP(fmt.Sprintf("id-%d", i)),
+				Username: gocloak.StringP(fmt.Sprintf("user-%d", i)),
+			})
+		}
+		mockGetGroupMembers(mKeycloak, c, *gs[i].ID, us)
+	}
+
+	res, err := c.ListGroups(context.TODO())
+	require.NoError(t, err)
+
+	assert.Len(t, res, 3)
+	assert.Len(t, res[0].Members, 0)
+	assert.Equal(t, "user-1", res[1].Members[0])
+	assert.Equal(t, "user-2", res[2].Members[1])
+}

--- a/keycloak/suite_test.go
+++ b/keycloak/suite_test.go
@@ -16,6 +16,14 @@ func mockLogin(mgc *MockGoCloak, c Client) {
 		AnyTimes()
 }
 
+func mockListGroups(mgc *MockGoCloak, c Client, groups []*gocloak.Group) {
+	mgc.EXPECT().
+		GetGroups(gomock.Any(), "token", c.Realm, gocloak.GetGroupsParams{}).
+		Return(groups, nil).
+		Times(1)
+
+}
+
 func mockGetGroups(mgc *MockGoCloak, c Client, groupName string, groups []*gocloak.Group) {
 	mgc.EXPECT().
 		GetGroups(gomock.Any(), "token", c.Realm, gocloak.GetGroupsParams{
@@ -42,7 +50,7 @@ func mockDeleteGroup(mgc *MockGoCloak, c Client, groupID string) {
 
 func mockGetGroupMembers(mgc *MockGoCloak, c Client, groupID string, users []*gocloak.User) {
 	mgc.EXPECT().
-		GetGroupMembers(gomock.Any(), "token", c.Realm, "foo-id", gomock.Any()).
+		GetGroupMembers(gomock.Any(), "token", c.Realm, groupID, gomock.Any()).
 		Return(users, nil).
 		Times(1)
 }

--- a/main.go
+++ b/main.go
@@ -10,19 +10,17 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"github.com/go-logr/logr"
 	"github.com/robfig/cron/v3"
 
 	orgv1 "github.com/appuio/control-api/apis/organization/v1"
 	controlv1 "github.com/appuio/control-api/apis/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/vshn/appuio-keycloak-adapter/controllers"
 	"github.com/vshn/appuio-keycloak-adapter/keycloak"
@@ -69,21 +67,22 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	ctx := ctrl.SetupSignalHandler()
 
-	kc := keycloak.NewClient(*host, *realm, *username, *password)
-	mgr, err := setupManager(kc, ctrl.Options{
-		Scheme:                 scheme,
-		MetricsBindAddress:     *metricsAddr,
-		Port:                   9443,
-		HealthProbeBindAddress: *probeAddr,
-		LeaderElection:         *enableLeaderElection,
-		LeaderElectionID:       "fe04906e.keycloak-adapter.vshn.net",
-	})
+	mgr, or, err := setupManager(
+		keycloak.NewClient(*host, *realm, *username, *password),
+		ctrl.Options{
+			Scheme:                 scheme,
+			MetricsBindAddress:     *metricsAddr,
+			Port:                   9443,
+			HealthProbeBindAddress: *probeAddr,
+			LeaderElection:         *enableLeaderElection,
+			LeaderElectionID:       "fe04906e.keycloak-adapter.vshn.net",
+		})
 	if err != nil {
 		setupLog.Error(err, "unable to setup manager")
 		os.Exit(1)
 	}
 
-	c, err := setupSync(ctx, kc, mgr.GetClient())
+	c, err := setupSync(ctx, or)
 	if err != nil {
 		setupLog.Error(err, "unable to setup sync")
 		os.Exit(1)
@@ -99,93 +98,40 @@ func main() {
 	<-c.Stop().Done()
 }
 
-func setupManager(kc controllers.KeycloakClient, opt ctrl.Options) (ctrl.Manager, error) {
+func setupManager(kc controllers.KeycloakClient, opt ctrl.Options) (ctrl.Manager, *controllers.OrganizationReconciler, error) {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), opt)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-
-	if err = (&controllers.OrganizationReconciler{
+  or := &controllers.OrganizationReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Keycloak: kc,
-	}).SetupWithManager(mgr); err != nil {
-		return nil, err
+	}
+	if err = or.SetupWithManager(mgr); err != nil {
+		return nil, nil, err
 	}
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return mgr, err
+	return mgr, or, err
 }
 
-func setupSync(ctx context.Context, keyC keycloak.Client, kubeC client.Client) (*cron.Cron, error) {
+func setupSync(ctx context.Context, r *controllers.OrganizationReconciler) (*cron.Cron, error) {
 	syncLog := ctrl.Log.WithName("sync")
 	c := cron.New()
 	_, err := c.AddFunc("@every 10s", func() {
 		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
-
-		gs, err := keyC.ListGroups(ctx)
+		ctx = logr.NewContext(ctx, syncLog)
+		err := r.Sync(ctx)
 		if err != nil {
-			syncLog.Error(err, "error listing Keycloak groups")
-			return
-		}
-		syncLog.WithValues("groups", gs).Info("got groups")
-
-		orgs := orgv1.OrganizationList{}
-		err = kubeC.List(ctx, &orgs)
-		if err != nil {
-			syncLog.Error(err, "error listing organizations")
-			return
-		}
-		syncLog.WithValues("orgs", orgs).Info("got organizations")
-
-		orgMap := map[string]struct{}{}
-		for _, o := range orgs.Items {
-			orgMap[o.Name] = struct{}{}
-		}
-
-		for _, g := range gs {
-			if _, ok := orgMap[g.Name]; !ok {
-				syncLog.WithValues("g", g).Info("creating org")
-				org := orgv1.Organization{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: g.Name,
-					},
-					Spec: orgv1.OrganizationSpec{
-						DisplayName: g.Name,
-					},
-				}
-				err := kubeC.Create(ctx, &org)
-				if err != nil {
-					syncLog.WithValues("org", org.Name).Error(err, "failed to create organization")
-					continue
-				}
-
-				orgMemb := controlv1.OrganizationMembers{}
-				err = kubeC.Get(ctx, types.NamespacedName{
-					Namespace: org.Name,
-					Name:      "members",
-				}, &orgMemb)
-				if err != nil {
-					syncLog.WithValues("org", org.Name).Error(err, "failed to get organization members")
-					continue
-				}
-				orgMemb.Spec.UserRefs = make([]controlv1.UserRef, len(g.Members))
-				for i, m := range g.Members {
-					orgMemb.Spec.UserRefs[i] = controlv1.UserRef{Name: m}
-				}
-				err = kubeC.Update(ctx, &orgMemb)
-				if err != nil {
-					syncLog.WithValues("org", org.Name).Error(err, "failed to update organization members")
-					continue
-				}
-			}
+			syncLog.Error(err, "failed to sync Keycloak groups")
 		}
 	})
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 
@@ -9,17 +10,23 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"github.com/robfig/cron/v3"
+
 	orgv1 "github.com/appuio/control-api/apis/organization/v1"
 	controlv1 "github.com/appuio/control-api/apis/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/vshn/appuio-keycloak-adapter/controllers"
 	"github.com/vshn/appuio-keycloak-adapter/keycloak"
+
 	//+kubebuilder:scaffold:imports
 	"time"
 )
@@ -43,70 +50,146 @@ func init() {
 	//+kubebuilder:scaffold:scheme
 }
 
-var metricsAddr string
-var enableLeaderElection bool
-var probeAddr string
-
-var host string
-var realm string
-var username string
-var password string
-
 func main() {
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
-	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
+	metricsAddr := flag.String("metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	enableLeaderElection := flag.Bool("leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	probeAddr := flag.String("health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 
-	flag.StringVar(&host, "keycloak-url", "", "The address of the Keycloak server (E.g. `https://keycloak.example.com`).")
-	flag.StringVar(&realm, "keycloak-realm", "", "The realm to sync the groups to.")
-	flag.StringVar(&username, "keycloak-username", "", "The username to log in to the Keycloak server.")
-	flag.StringVar(&password, "keycloak-password", "", "The password to log in to the Keycloak server.")
+	host := flag.String("keycloak-url", "", "The address of the Keycloak server (E.g. `https://keycloak.example.com`).")
+	realm := flag.String("keycloak-realm", "", "The realm to sync the groups to.")
+	username := flag.String("keycloak-username", "", "The username to log in to the Keycloak server.")
+	password := flag.String("keycloak-password", "", "The password to log in to the Keycloak server.")
 
-	opts := zap.Options{
-		Development: true,
-	}
+	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	ctx := ctrl.SetupSignalHandler()
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	kc := keycloak.NewClient(*host, *realm, *username, *password)
+	mgr, err := setupManager(kc, ctrl.Options{
 		Scheme:                 scheme,
-		MetricsBindAddress:     metricsAddr,
+		MetricsBindAddress:     *metricsAddr,
 		Port:                   9443,
-		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "fe04906e.my.domain",
+		HealthProbeBindAddress: *probeAddr,
+		LeaderElection:         *enableLeaderElection,
+		LeaderElectionID:       "fe04906e.keycloak-adapter.vshn.net",
 	})
 	if err != nil {
-		setupLog.Error(err, "unable to start manager")
+		setupLog.Error(err, "unable to setup manager")
 		os.Exit(1)
+	}
+
+	c, err := setupSync(ctx, kc, mgr.GetClient())
+	if err != nil {
+		setupLog.Error(err, "unable to setup sync")
+		os.Exit(1)
+	}
+	c.Start()
+
+	setupLog.Info("starting manager")
+	if err := mgr.Start(ctx); err != nil {
+		setupLog.Error(err, "problem running manager")
+		os.Exit(1)
+	}
+	setupLog.Info("stopping..")
+	<-c.Stop().Done()
+}
+
+func setupManager(kc controllers.KeycloakClient, opt ctrl.Options) (ctrl.Manager, error) {
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), opt)
+	if err != nil {
+		return nil, err
 	}
 
 	if err = (&controllers.OrganizationReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
-		Keycloak: keycloak.NewClient(host, realm, username, password),
+		Keycloak: kc,
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "Organization")
-		os.Exit(1)
+		return nil, err
 	}
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up health check")
-		os.Exit(1)
+		return nil, err
 	}
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up ready check")
-		os.Exit(1)
+		return nil, err
 	}
+	return mgr, err
+}
 
-	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		setupLog.Error(err, "problem running manager")
-		os.Exit(1)
+func setupSync(ctx context.Context, keyC keycloak.Client, kubeC client.Client) (*cron.Cron, error) {
+	syncLog := ctrl.Log.WithName("sync")
+	c := cron.New()
+	_, err := c.AddFunc("@every 10s", func() {
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+
+		gs, err := keyC.ListGroups(ctx)
+		if err != nil {
+			syncLog.Error(err, "error listing Keycloak groups")
+			return
+		}
+		syncLog.WithValues("groups", gs).Info("got groups")
+
+		orgs := orgv1.OrganizationList{}
+		err = kubeC.List(ctx, &orgs)
+		if err != nil {
+			syncLog.Error(err, "error listing organizations")
+			return
+		}
+		syncLog.WithValues("orgs", orgs).Info("got organizations")
+
+		orgMap := map[string]struct{}{}
+		for _, o := range orgs.Items {
+			orgMap[o.Name] = struct{}{}
+		}
+
+		for _, g := range gs {
+			if _, ok := orgMap[g.Name]; !ok {
+				syncLog.WithValues("g", g).Info("creating org")
+				org := orgv1.Organization{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: g.Name,
+					},
+					Spec: orgv1.OrganizationSpec{
+						DisplayName: g.Name,
+					},
+				}
+				err := kubeC.Create(ctx, &org)
+				if err != nil {
+					syncLog.WithValues("org", org.Name).Error(err, "failed to create organization")
+					continue
+				}
+
+				orgMemb := controlv1.OrganizationMembers{}
+				err = kubeC.Get(ctx, types.NamespacedName{
+					Namespace: org.Name,
+					Name:      "members",
+				}, &orgMemb)
+				if err != nil {
+					syncLog.WithValues("org", org.Name).Error(err, "failed to get organization members")
+					continue
+				}
+				orgMemb.Spec.UserRefs = make([]controlv1.UserRef, len(g.Members))
+				for i, m := range g.Members {
+					orgMemb.Spec.UserRefs[i] = controlv1.UserRef{Name: m}
+				}
+				err = kubeC.Update(ctx, &orgMemb)
+				if err != nil {
+					syncLog.WithValues("org", org.Name).Error(err, "failed to update organization members")
+					continue
+				}
+			}
+		}
+	})
+	if err != nil {
+		return nil, err
 	}
+	return c, nil
 }

--- a/main.go
+++ b/main.go
@@ -103,7 +103,7 @@ func setupManager(kc controllers.KeycloakClient, opt ctrl.Options) (ctrl.Manager
 	if err != nil {
 		return nil, nil, err
 	}
-  or := &controllers.OrganizationReconciler{
+	or := &controllers.OrganizationReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Keycloak: kc,


### PR DESCRIPTION
## Summary

This PR introduces a periodic import from Keycloak. It uses a cron library to do this. 

Another option would have been to add a reconcile loop on a custom resource, similarly to https://github.com/appuio/keycloak-attribute-sync-controller.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
