### PR TITLE
Fix session leak by actually logging out 

### DIFF
--- a/keycloak/ZZ_mock_gocloak_test.go
+++ b/keycloak/ZZ_mock_gocloak_test.go
@@ -151,3 +151,17 @@ func (mr *MockGoCloakMockRecorder) LoginAdmin(ctx, username, password, realm int
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoginAdmin", reflect.TypeOf((*MockGoCloak)(nil).LoginAdmin), ctx, username, password, realm)
 }
+
+// LogoutUserSession mocks base method.
+func (m *MockGoCloak) LogoutUserSession(ctx context.Context, accessToken, realm, session string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LogoutUserSession", ctx, accessToken, realm, session)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LogoutUserSession indicates an expected call of LogoutUserSession.
+func (mr *MockGoCloakMockRecorder) LogoutUserSession(ctx, accessToken, realm, session interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogoutUserSession", reflect.TypeOf((*MockGoCloak)(nil).LogoutUserSession), ctx, accessToken, realm, session)
+}

--- a/keycloak/suite_test.go
+++ b/keycloak/suite_test.go
@@ -11,8 +11,13 @@ func mockLogin(mgc *MockGoCloak, c Client) {
 	mgc.EXPECT().
 		LoginAdmin(gomock.Any(), c.Username, c.Password, c.Realm).
 		Return(&gocloak.JWT{
-			AccessToken: "token",
+			SessionState: "session",
+			AccessToken:  "token",
 		}, nil).
+		AnyTimes()
+	mgc.EXPECT().
+		LogoutUserSession(gomock.Any(), "token", c.Realm, "session").
+		Return(nil).
 		AnyTimes()
 }
 
@@ -21,7 +26,6 @@ func mockListGroups(mgc *MockGoCloak, c Client, groups []*gocloak.Group) {
 		GetGroups(gomock.Any(), "token", c.Realm, gocloak.GetGroupsParams{}).
 		Return(groups, nil).
 		Times(1)
-
 }
 
 func mockGetGroups(mgc *MockGoCloak, c Client, groupName string, groups []*gocloak.Group) {


### PR DESCRIPTION
## Summary

We need to explicitly log out of keycloak. Otherwise we leak sessions

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
