### PR TITLE
Add option to bind ClusterRoles to users of imported groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Usage of ./appuio-keycloak-adapter:
       A cron style schedule for the organization synchronization interval. (default "@every 5m")
   -sync-timeout duration
       The timeout for a single synchronization run. (default 10s)
+  -sync-roles string
+    	A comma separated list of cluster roles to bind to users when importing a new organization.
 ```
 
 ### Authenticating to Keycloak
@@ -49,7 +51,7 @@ The following permissions must be associated to the user:
 
 In addition to mirroring changes on `Organization` resources to Keycloak, this component will also periodically import any top-level Keycloak group as `Organizations`
 It will however only create `Organization` resources and will never update them.
-This import schedule is configured through the `sync-schedule` flag.
+This import schedule is configured through the `sync-schedule` flag and the `ClusterRoles` specified in the `sync-roles` flag will be bound to every member of the Keycloak group at the time of the initial import.
 
 ## Development
 

--- a/controllers/organization_controller.go
+++ b/controllers/organization_controller.go
@@ -23,6 +23,9 @@ type OrganizationReconciler struct {
 	Scheme   *runtime.Scheme
 
 	Keycloak KeycloakClient
+
+	// ClusteRoles to give to group members when importing
+	SyncClusterRoles []string
 }
 
 //go:generate go run github.com/golang/mock/mockgen -destination=./ZZ_mock_eventrecorder_test.go -package controllers_test k8s.io/client-go/tools/record EventRecorder

--- a/controllers/organization_controller_sync.go
+++ b/controllers/organization_controller_sync.go
@@ -31,7 +31,6 @@ func (r *OrganizationReconciler) Sync(ctx context.Context) error {
 	}
 
 	var groupErr error
-
 	for _, g := range gs {
 		org, err := r.syncGroup(ctx, g, orgMap[g.Name])
 		if err != nil {

--- a/controllers/organization_controller_sync.go
+++ b/controllers/organization_controller_sync.go
@@ -9,6 +9,8 @@ import (
 	controlv1 "github.com/appuio/control-api/apis/v1"
 	"github.com/vshn/appuio-keycloak-adapter/keycloak"
 
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -64,6 +66,10 @@ func (r *OrganizationReconciler) syncGroup(ctx context.Context, g keycloak.Group
 	if org.Annotations[orgImportAnnot] == "true" {
 		logger.V(1).WithValues("group", g).Info("updating organization members")
 		err := r.updateOrganizationMembersFromGroup(ctx, g)
+		if err != nil {
+			return org, err
+		}
+		err = r.setRolebindingsFromGroup(ctx, g)
 		if err != nil {
 			return org, err
 		}
@@ -125,4 +131,50 @@ func (r *OrganizationReconciler) updateOrganizationMembersFromGroup(ctx context.
 		orgMemb.Spec.UserRefs[i] = controlv1.UserRef{Name: m}
 	}
 	return r.Update(ctx, &orgMemb)
+}
+
+func (r *OrganizationReconciler) setRolebindingsFromGroup(ctx context.Context, group keycloak.Group) error {
+	subjects := []rbacv1.Subject{}
+	for _, m := range group.Members {
+		subjects = append(subjects, rbacv1.Subject{
+			Kind:     rbacv1.UserKind,
+			APIGroup: rbacv1.GroupName,
+			Name:     m,
+		})
+	}
+
+	for _, rbName := range r.SyncClusterRoles {
+
+		rb := rbacv1.RoleBinding{}
+		err := r.Get(ctx, types.NamespacedName{Namespace: group.Name, Name: rbName}, &rb)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+		if apierrors.IsNotFound(err) {
+			rb := rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: group.Name,
+					Name:      rbName,
+				},
+				Subjects: subjects,
+				RoleRef: rbacv1.RoleRef{
+					Kind:     "ClusterRole",
+					APIGroup: rbacv1.GroupName,
+					Name:     rbName,
+				},
+			}
+
+			err = r.Create(ctx, &rb)
+			if err != nil {
+				return err
+			}
+		} else {
+			rb.Subjects = subjects
+			err = r.Update(ctx, &rb)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

This PR introduces the option to bind existing clusterroles to the members of a newly imported organization. This fixes the issue that after importing an organization from keycloak, there is no organization admin, able to manage it.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
