### PR TITLE
Allow setting a top-level group as base for the organization sync

### DIFF
--- a/keycloak/client.go
+++ b/keycloak/client.go
@@ -388,10 +388,14 @@ func (c Client) filterTreeWithRoot(groups []*gocloak.Group) []gocloak.Group {
 	}
 
 	for _, g := range groups {
-		if *g.Name == c.RootGroup && g.SubGroups != nil {
-			return trimPath(*g.SubGroups)
+		if *g.Name == c.RootGroup {
+			if g.SubGroups != nil {
+				return trimPath(*g.SubGroups)
+			}
+			return []gocloak.Group{}
 		}
 	}
+
 	return nil
 }
 

--- a/keycloak/client_delete_test.go
+++ b/keycloak/client_delete_test.go
@@ -35,6 +35,26 @@ func TestDeleteGroup_simple(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDeleteGroup_RootGroup(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mKeycloak := NewMockGoCloak(ctrl)
+	c := Client{
+		Client:    mKeycloak,
+		RootGroup: "root-group",
+	}
+	mockLogin(mKeycloak, c)
+	mockGetGroups(mKeycloak, c, "foo-gmbh",
+		[]*gocloak.Group{
+			newGocloakGroup("foo-id", "root-group", "foo-gmbh"),
+		})
+	mockDeleteGroup(mKeycloak, c, "foo-id")
+
+	err := c.DeleteGroup(context.TODO(), "foo-gmbh")
+	require.NoError(t, err)
+}
+
 func TestDeleteGroup_subgroup(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/keycloak/client_list_test.go
+++ b/keycloak/client_list_test.go
@@ -64,7 +64,7 @@ func TestListGroups_simple(t *testing.T) {
 	assert.Equal(t, "user-2", res[2].Members[1])
 }
 
-func TestListGroups_root_group(t *testing.T) {
+func TestListGroups_RootGroup(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -99,6 +99,28 @@ func TestListGroups_root_group(t *testing.T) {
 	assert.Len(t, res, 2)
 	assert.Equal(t, "/foo-gmbh", res[0].Path())
 	assert.Equal(t, "/foo-gmbh/foo-team", res[1].Path())
+}
+
+func TestListGroups_RootGroup_no_groups_under_root(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mKeycloak := NewMockGoCloak(ctrl)
+	c := Client{
+		Client:    mKeycloak,
+		RootGroup: "root-group",
+	}
+
+	gs := []*gocloak.Group{
+		newGocloakGroup("foo-id", "foo-gmbh"),
+		newGocloakGroup("root-group-id", "root-group"),
+	}
+	mockLogin(mKeycloak, c)
+	mockListGroups(mKeycloak, c, gs)
+
+	res, err := c.ListGroups(context.TODO())
+	require.NoError(t, err)
+	assert.Len(t, res, 0)
 }
 
 func TestListGroups_RootGroup_RootNotFound(t *testing.T) {

--- a/keycloak/client_list_test.go
+++ b/keycloak/client_list_test.go
@@ -21,10 +21,7 @@ func TestListGroups_simple(t *testing.T) {
 
 	mKeycloak := NewMockGoCloak(ctrl)
 	c := Client{
-		Client:   mKeycloak,
-		Realm:    "foo",
-		Username: "bar",
-		Password: "buzz",
+		Client: mKeycloak,
 	}
 
 	gs := []*gocloak.Group{
@@ -65,4 +62,61 @@ func TestListGroups_simple(t *testing.T) {
 
 	assert.Equal(t, "user-1", res[1].Members[0])
 	assert.Equal(t, "user-2", res[2].Members[1])
+}
+
+func TestListGroups_root_group(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mKeycloak := NewMockGoCloak(ctrl)
+	c := Client{
+		Client:    mKeycloak,
+		RootGroup: "root-group",
+	}
+
+	gs := []*gocloak.Group{
+		newGocloakGroup("foo-id", "foo-gmbh"),
+		func() *gocloak.Group {
+			g := newGocloakGroup("root-group-id", "root-group")
+			g.SubGroups = &[]gocloak.Group{
+				func() gocloak.Group {
+					g := *newGocloakGroup("foo-gmbh-id", "root-group", "foo-gmbh")
+					g.SubGroups = &[]gocloak.Group{*newGocloakGroup("foo-team-id", "root-group", "foo-gmbh", "foo-team")}
+					return g
+				}()}
+			return g
+		}(),
+	}
+	mockLogin(mKeycloak, c)
+	mockListGroups(mKeycloak, c, gs)
+	for _, id := range []string{"foo-gmbh-id", "foo-team-id"} {
+		mockGetGroupMembers(mKeycloak, c, id, []*gocloak.User{})
+	}
+
+	res, err := c.ListGroups(context.TODO())
+	require.NoError(t, err)
+
+	assert.Len(t, res, 2)
+	assert.Equal(t, "/foo-gmbh", res[0].Path())
+	assert.Equal(t, "/foo-gmbh/foo-team", res[1].Path())
+}
+
+func TestListGroups_RootGroup_RootNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mKeycloak := NewMockGoCloak(ctrl)
+	c := Client{
+		Client:    mKeycloak,
+		RootGroup: "root-group",
+	}
+
+	gs := []*gocloak.Group{
+		newGocloakGroup("foo-id", "foo-gmbh"),
+	}
+	mockLogin(mKeycloak, c)
+	mockListGroups(mKeycloak, c, gs)
+
+	_, err := c.ListGroups(context.TODO())
+	require.Error(t, err)
 }

--- a/main.go
+++ b/main.go
@@ -61,6 +61,8 @@ func main() {
 	username := flag.String("keycloak-username", "", "The username to log in to the Keycloak server.")
 	password := flag.String("keycloak-password", "", "The password to log in to the Keycloak server.")
 
+	organizationRoot := flag.String("organization-root", "", "The Keycloak top-level group under which the organizations are synced.")
+
 	crontab := flag.String("sync-schedule", "@every 5m", "A cron style schedule for the organization synchronization interval.")
 	timeout := flag.Duration("sync-timeout", 10*time.Second, "The timeout for a single synchronization run.")
 	syncRoles := flag.String("sync-roles", "", "A comma separated list of cluster roles to bind to users when importing a new organization.")
@@ -77,8 +79,11 @@ func main() {
 		roles = strings.Split(*syncRoles, ",")
 	}
 
+	kc := keycloak.NewClient(*host, *realm, *username, *password)
+	kc.RootGroup = *organizationRoot
+
 	mgr, or, err := setupManager(
-		keycloak.NewClient(*host, *realm, *username, *password),
+		kc,
 		roles,
 		ctrl.Options{
 			Scheme:                 scheme,


### PR DESCRIPTION
## Summary

* Adds a new optional command-line parameter `-organization-root`
* If set, `appuio-keycloak-adapter` uses the given group as the root group under which it syncs all groups

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
