### PR TITLE
Keycloak Client: Separate target realm from login realm

### DIFF
--- a/keycloak/client_login_test.go
+++ b/keycloak/client_login_test.go
@@ -1,0 +1,69 @@
+package keycloak_test
+
+import (
+	"context"
+	"testing"
+
+	gocloak "github.com/Nerzal/gocloak/v11"
+	gomock "github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	. "github.com/vshn/appuio-keycloak-adapter/keycloak"
+)
+
+func TestLogin(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mKeycloak := NewMockGoCloak(ctrl)
+	c := Client{
+		Realm:  "target-realm",
+		Client: mKeycloak,
+	}
+
+	mKeycloak.EXPECT().
+		LoginAdmin(gomock.Any(), c.Username, c.Password, "target-realm").
+		Return(&gocloak.JWT{
+			SessionState: "session",
+			AccessToken:  "token",
+		}, nil).
+		AnyTimes()
+	mKeycloak.EXPECT().
+		LogoutUserSession(gomock.Any(), "token", "target-realm", "session").
+		Return(nil).
+		AnyTimes()
+
+	mockListGroups(mKeycloak, c, []*gocloak.Group{})
+
+	_, err := c.ListGroups(context.Background())
+	require.NoError(t, err)
+}
+
+func TestLogin_WithLoginRealm(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mKeycloak := NewMockGoCloak(ctrl)
+	c := Client{
+		Realm:      "target-realm",
+		LoginRealm: "login-realm",
+		Client:     mKeycloak,
+	}
+
+	mKeycloak.EXPECT().
+		LoginAdmin(gomock.Any(), c.Username, c.Password, "login-realm").
+		Return(&gocloak.JWT{
+			SessionState: "session",
+			AccessToken:  "token",
+		}, nil).
+		AnyTimes()
+	mKeycloak.EXPECT().
+		LogoutUserSession(gomock.Any(), "token", "login-realm", "session").
+		Return(nil).
+		AnyTimes()
+
+	mockListGroups(mKeycloak, c, []*gocloak.Group{})
+
+	_, err := c.ListGroups(context.Background())
+	require.NoError(t, err)
+}

--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ func main() {
 
 	host := flag.String("keycloak-url", "", "The address of the Keycloak server (E.g. `https://keycloak.example.com`).")
 	realm := flag.String("keycloak-realm", "", "The realm to sync the groups to.")
+	loginRealm := flag.String("keycloak-login-realm", "", "The realm to log in to the Keycloak server. `keycloak-realm` is used if not set.")
 	username := flag.String("keycloak-username", "", "The username to log in to the Keycloak server.")
 	password := flag.String("keycloak-password", "", "The password to log in to the Keycloak server.")
 
@@ -81,6 +82,7 @@ func main() {
 
 	kc := keycloak.NewClient(*host, *realm, *username, *password)
 	kc.RootGroup = *organizationRoot
+	kc.LoginRealm = *loginRealm
 
 	mgr, or, err := setupManager(
 		kc,


### PR DESCRIPTION
## Summary

* Admin users can be in other realms than the realm they try to manage. Reflect this in the client.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
