### PR TITLE
Fix creating rolebindings for imported organizations

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -115,8 +115,4 @@ rules:
   - rolebindings
   - subjects
   verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
+  - '*'

--- a/controllers/periodic_syncer.go
+++ b/controllers/periodic_syncer.go
@@ -36,7 +36,7 @@ type PeriodicSyncer struct {
 //+kubebuilder:rbac:groups=appuio.io,resources=teams,verbs=create
 //+kubebuilder:rbac:groups=appuio.io,resources=users,verbs=create
 //+kubebuilder:rbac:groups=organization.appuio.io;rbac.appuio.io,resources=organizations,verbs=create
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=subjects;rolebindings,verbs=get;list;create;update;patch
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=subjects;rolebindings,verbs=*
 
 // Sync lists all Keycloak groups in the realm and creates corresponding Organizations if they do not exist
 func (r *PeriodicSyncer) Sync(ctx context.Context) error {

--- a/controllers/periodic_syncer.go
+++ b/controllers/periodic_syncer.go
@@ -29,7 +29,8 @@ type PeriodicSyncer struct {
 	Keycloak KeycloakClient
 
 	// SyncClusterRoles to give to group members when importing
-	SyncClusterRoles []string
+	SyncClusterRoles           []string
+	SyncClusterRolesUserPrefix string
 }
 
 //+kubebuilder:rbac:groups=appuio.io,resources=organizationmembers,verbs=create
@@ -267,7 +268,7 @@ func (r *PeriodicSyncer) setRolebindingsFromGroup(ctx context.Context, group key
 		subjects = append(subjects, rbacv1.Subject{
 			Kind:     rbacv1.UserKind,
 			APIGroup: rbacv1.GroupName,
-			Name:     m.Username,
+			Name:     r.SyncClusterRolesUserPrefix + m.Username,
 		})
 	}
 

--- a/controllers/periodic_syncer_test.go
+++ b/controllers/periodic_syncer_test.go
@@ -61,10 +61,11 @@ func Test_Sync_Success(t *testing.T) {
 		Times(1)
 
 	err := (&PeriodicSyncer{
-		Client:           c,
-		Recorder:         erMock,
-		Keycloak:         keyMock,
-		SyncClusterRoles: []string{"import-role", "existing-role"},
+		Client:                     c,
+		Recorder:                   erMock,
+		Keycloak:                   keyMock,
+		SyncClusterRoles:           []string{"import-role", "existing-role"},
+		SyncClusterRolesUserPrefix: "appuio#",
 	}).Sync(ctx)
 	require.NoError(t, err)
 
@@ -83,12 +84,12 @@ func Test_Sync_Success(t *testing.T) {
 		{
 			Kind:     rbacv1.UserKind,
 			APIGroup: rbacv1.GroupName,
-			Name:     "bar3",
+			Name:     "appuio#bar3",
 		},
 		{
 			Kind:     rbacv1.UserKind,
 			APIGroup: rbacv1.GroupName,
-			Name:     "bar",
+			Name:     "appuio#bar",
 		},
 	}, rb.Subjects, "create new role")
 	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "existing-role", Namespace: "bar"}, &rb))
@@ -96,12 +97,12 @@ func Test_Sync_Success(t *testing.T) {
 		{
 			Kind:     rbacv1.UserKind,
 			APIGroup: rbacv1.GroupName,
-			Name:     "bar3",
+			Name:     "appuio#bar3",
 		},
 		{
 			Kind:     rbacv1.UserKind,
 			APIGroup: rbacv1.GroupName,
-			Name:     "bar",
+			Name:     "appuio#bar",
 		},
 	}, rb.Subjects, "update exiting role")
 


### PR DESCRIPTION
- [Prefix users in imported rolebindigs](https://github.com/vshn/appuio-keycloak-adapter/pull/28/commits/5c6c1fdbc5af52615d11ea25bca88647c9d9d042)
- [Fix creating rolebindings with admin permissions](https://github.com/vshn/appuio-keycloak-adapter/pull/28/commits/78624d6f61b188611c830ea64f7849fcd16677b5)

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
