### PR TITLE
Fix teams synced as top-level organization

### DIFF
--- a/controllers/team_controller.go
+++ b/controllers/team_controller.go
@@ -110,7 +110,7 @@ func buildTeamKeycloakGroup(team *controlv1.Team) keycloak.Group {
 		groupMem = append(groupMem, u.Name)
 	}
 
-	return keycloak.NewGroup(team.Namespace, team.Name).WithMemberNames(groupMem...)
+	return keycloak.NewGroup(team.Spec.DisplayName, team.Namespace, team.Name).WithMemberNames(groupMem...)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/team_controller_test.go
+++ b/controllers/team_controller_test.go
@@ -22,7 +22,7 @@ func Test_TeamController_Reconcile_Success(t *testing.T) {
 	ctx := context.Background()
 
 	c, keyMock, _ := prepareTest(t, barTeam)
-	group := keycloak.NewGroup(barTeam.Namespace, barTeam.Name).WithMemberNames("baz", "qux")
+	group := keycloak.NewGroup(barTeam.Spec.DisplayName, barTeam.Namespace, barTeam.Name).WithMemberNames("baz", "qux")
 	keyMock.EXPECT().
 		PutGroup(gomock.Any(), group).
 		Return(group, nil).
@@ -50,7 +50,7 @@ func Test_TeamController_Reconcile_Failure(t *testing.T) {
 	ctx := context.Background()
 
 	c, keyMock, erMock := prepareTest(t, barTeam)
-	group := keycloak.NewGroup(barTeam.Namespace, barTeam.Name).WithMemberNames("baz", "qux")
+	group := keycloak.NewGroup(barTeam.Spec.DisplayName, barTeam.Namespace, barTeam.Name).WithMemberNames("baz", "qux")
 	keyMock.EXPECT().
 		PutGroup(gomock.Any(), group).
 		Return(keycloak.Group{}, errors.New("create failed")).
@@ -83,7 +83,7 @@ func Test_TeamController_Reconcile_Member_Failure(t *testing.T) {
 	ctx := context.Background()
 
 	c, keyMock, erMock := prepareTest(t, barTeam)
-	group := keycloak.NewGroup(barTeam.Namespace, barTeam.Name).WithMemberNames("baz", "qux")
+	group := keycloak.NewGroup(barTeam.Spec.DisplayName, barTeam.Namespace, barTeam.Name).WithMemberNames("baz", "qux")
 	keyMock.EXPECT().
 		PutGroup(gomock.Any(), group).
 		Return(keycloak.Group{}, &keycloak.MembershipSyncErrors{


### PR DESCRIPTION
#57 changed the `keycloak.NewGroup` signature to take the first argument as the display name. The teams controller was forgotten. The organization of the team was used as the display name and removed from the path. This made the team look like an organization after syncing them to Keycloak.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
