### PR TITLE
Support API changes in Keycloak 23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.0.0 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/safetext v0.0.0-20230106111101-7156a760e523 // indirect
+	github.com/jarcoal/httpmock v1.3.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 )
 
@@ -40,7 +41,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
-	github.com/go-resty/resty/v2 v2.7.0 // indirect
+	github.com/go-resty/resty/v2 v2.7.0
 	github.com/gobuffalo/flect v1.0.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
@@ -62,7 +63,7 @@ require (
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.17.0 // indirect
 	github.com/prometheus/client_model v0.4.1-0.20230718164431-9a2bf3000d16 // indirect

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,8 @@ github.com/imdario/mergo v0.3.15/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+h
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jarcoal/httpmock v1.3.1 h1:iUx3whfZWVf3jT01hQTO/Eo5sAYtB2/rqaUuOtpInww=
+github.com/jarcoal/httpmock v1.3.1/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=

--- a/keycloak/ZZ_mock_gocloak_test.go
+++ b/keycloak/ZZ_mock_gocloak_test.go
@@ -152,6 +152,21 @@ func (mr *MockGoCloakMockRecorder) GetRequestWithBearerAuth(ctx, token interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRequestWithBearerAuth", reflect.TypeOf((*MockGoCloak)(nil).GetRequestWithBearerAuth), ctx, token)
 }
 
+// GetServerInfo mocks base method.
+func (m *MockGoCloak) GetServerInfo(ctx context.Context, accessToken string) (*gocloak.ServerInfoRepresentation, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetServerInfo", ctx, accessToken)
+	ret0, _ := ret[0].(*gocloak.ServerInfoRepresentation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetServerInfo indicates an expected call of GetServerInfo.
+func (mr *MockGoCloakMockRecorder) GetServerInfo(ctx, accessToken interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServerInfo", reflect.TypeOf((*MockGoCloak)(nil).GetServerInfo), ctx, accessToken)
+}
+
 // GetUsers mocks base method.
 func (m *MockGoCloak) GetUsers(ctx context.Context, accessToken, realm string, params gocloak.GetUsersParams) ([]*gocloak.User, error) {
 	m.ctrl.T.Helper()

--- a/keycloak/ZZ_mock_gocloak_test.go
+++ b/keycloak/ZZ_mock_gocloak_test.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gocloak "github.com/Nerzal/gocloak/v13"
+	resty "github.com/go-resty/resty/v2"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -135,6 +136,20 @@ func (m *MockGoCloak) GetGroups(ctx context.Context, accessToken, realm string, 
 func (mr *MockGoCloakMockRecorder) GetGroups(ctx, accessToken, realm, params interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroups", reflect.TypeOf((*MockGoCloak)(nil).GetGroups), ctx, accessToken, realm, params)
+}
+
+// GetRequestWithBearerAuth mocks base method.
+func (m *MockGoCloak) GetRequestWithBearerAuth(ctx context.Context, token string) *resty.Request {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRequestWithBearerAuth", ctx, token)
+	ret0, _ := ret[0].(*resty.Request)
+	return ret0
+}
+
+// GetRequestWithBearerAuth indicates an expected call of GetRequestWithBearerAuth.
+func (mr *MockGoCloakMockRecorder) GetRequestWithBearerAuth(ctx, token interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRequestWithBearerAuth", reflect.TypeOf((*MockGoCloak)(nil).GetRequestWithBearerAuth), ctx, token)
 }
 
 // GetUsers mocks base method.

--- a/keycloak/client_list_test.go
+++ b/keycloak/client_list_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	gocloak "github.com/Nerzal/gocloak/v13"
+	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -19,10 +20,19 @@ func TestListGroups_simple(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	rst := setupHttpMock()
+	defer httpmock.DeactivateAndReset()
+
 	mKeycloak := NewMockGoCloak(ctrl)
 	c := Client{
 		Client: mKeycloak,
+		Host:   "https://example.com",
+		Realm:  "myrealm",
 	}
+
+	setupChildGroupErrorResponse(c, "foo-id")
+	setupChildGroupErrorResponse(c, "bar-id")
+	setupChildGroupErrorResponse(c, "parent-id")
 
 	gs := []*gocloak.Group{
 		newGocloakGroup("Foo Inc.", "foo-id", "foo-gmbh"),
@@ -35,6 +45,63 @@ func TestListGroups_simple(t *testing.T) {
 	}
 	mockLogin(mKeycloak, c)
 	mockListGroups(mKeycloak, c, gs)
+	mockKeycloakSubgroups(mKeycloak, rst, 3)
+	for i, id := range []string{"foo-id", "bar-id", "parent-id", "qux-id"} {
+		us := []*gocloak.User{}
+		for j := 0; j < i; j++ {
+			us = append(us, &gocloak.User{
+				ID:       gocloak.StringP(fmt.Sprintf("id-%d", i)),
+				Username: gocloak.StringP(fmt.Sprintf("user-%d", i)),
+			})
+		}
+		mockGetGroupMembers(mKeycloak, c, id, us)
+	}
+
+	res, err := c.ListGroups(context.TODO())
+	require.NoError(t, err)
+
+	assert.Len(t, res, 4)
+	assert.Equal(t, "/foo-gmbh", res[0].Path())
+	assert.Equal(t, "/bar-gmbh", res[1].Path())
+	assert.Equal(t, "/parent-gmbh", res[2].Path())
+	assert.Equal(t, "/parent-gmbh/qux-team", res[3].Path())
+
+	assert.Len(t, res[0].Members, 0)
+	assert.Len(t, res[1].Members, 1)
+	assert.Len(t, res[2].Members, 2)
+	assert.Len(t, res[3].Members, 3)
+
+	assert.Equal(t, "user-1", res[1].Members[0].Username)
+	assert.Equal(t, "user-2", res[2].Members[1].Username)
+}
+
+func TestListGroups_simple_keycloak23(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	rst := setupHttpMock()
+	defer httpmock.DeactivateAndReset()
+
+	mKeycloak := NewMockGoCloak(ctrl)
+	c := Client{
+		Client: mKeycloak,
+		Host:   "https://example.com",
+		Realm:  "myrealm",
+	}
+
+	subGroups := &[]gocloak.Group{*newGocloakGroup("Parent GmbH", "qux-id", "parent-gmbh", "qux-team")}
+	setupChildGroupResponse(c, "foo-id", make([]gocloak.Group, 0))
+	setupChildGroupResponse(c, "bar-id", make([]gocloak.Group, 0))
+	setupChildGroupResponse(c, "parent-id", *subGroups)
+
+	gs := []*gocloak.Group{
+		newGocloakGroup("Foo Inc.", "foo-id", "foo-gmbh"),
+		newGocloakGroup("Bar Inc.", "bar-id", "bar-gmbh"),
+		newGocloakGroup("", "parent-id", "parent-gmbh"),
+	}
+	mockLogin(mKeycloak, c)
+	mockListGroups(mKeycloak, c, gs)
+	mockKeycloakSubgroups(mKeycloak, rst, 3)
 	for i, id := range []string{"foo-id", "bar-id", "parent-id", "qux-id"} {
 		us := []*gocloak.User{}
 		for j := 0; j < i; j++ {
@@ -68,12 +135,19 @@ func TestListGroups_RootGroup(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	rst := setupHttpMock()
+	defer httpmock.DeactivateAndReset()
+
 	mKeycloak := NewMockGoCloak(ctrl)
 	c := Client{
 		Client:    mKeycloak,
 		RootGroup: "root-group",
+		Host:      "https://example.com",
+		Realm:     "myrealm",
 	}
 
+	setupChildGroupErrorResponse(c, "foo-id")
+	setupChildGroupErrorResponse(c, "root-group-id")
 	gs := []*gocloak.Group{
 		newGocloakGroup("Foo Inc.", "foo-id", "foo-gmbh"),
 		func() *gocloak.Group {
@@ -89,6 +163,7 @@ func TestListGroups_RootGroup(t *testing.T) {
 	}
 	mockLogin(mKeycloak, c)
 	mockListGroups(mKeycloak, c, gs)
+	mockKeycloakSubgroups(mKeycloak, rst, 2)
 	for _, id := range []string{"foo-gmbh-id", "foo-team-id"} {
 		mockGetGroupMembers(mKeycloak, c, id, []*gocloak.User{})
 	}
@@ -105,11 +180,19 @@ func TestListGroups_RootGroup_no_groups_under_root(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	rst := setupHttpMock()
+	defer httpmock.DeactivateAndReset()
+
 	mKeycloak := NewMockGoCloak(ctrl)
 	c := Client{
 		Client:    mKeycloak,
 		RootGroup: "root-group",
+		Host:      "https://example.com",
+		Realm:     "myrealm",
 	}
+
+	setupChildGroupErrorResponse(c, "foo-id")
+	setupChildGroupErrorResponse(c, "root-group-id")
 
 	gs := []*gocloak.Group{
 		newGocloakGroup("Foo Inc.", "foo-id", "foo-gmbh"),
@@ -117,6 +200,7 @@ func TestListGroups_RootGroup_no_groups_under_root(t *testing.T) {
 	}
 	mockLogin(mKeycloak, c)
 	mockListGroups(mKeycloak, c, gs)
+	mockKeycloakSubgroups(mKeycloak, rst, 2)
 
 	res, err := c.ListGroups(context.TODO())
 	require.NoError(t, err)
@@ -127,17 +211,23 @@ func TestListGroups_RootGroup_RootNotFound(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	rst := setupHttpMock()
+	defer httpmock.DeactivateAndReset()
+
 	mKeycloak := NewMockGoCloak(ctrl)
 	c := Client{
 		Client:    mKeycloak,
 		RootGroup: "root-group",
 	}
 
+	setupChildGroupErrorResponse(c, "foo-id")
+
 	gs := []*gocloak.Group{
 		newGocloakGroup("Foo Inc.", "foo-id", "foo-gmbh"),
 	}
 	mockLogin(mKeycloak, c)
 	mockListGroups(mKeycloak, c, gs)
+	mockKeycloakSubgroups(mKeycloak, rst, 1)
 
 	_, err := c.ListGroups(context.TODO())
 	require.Error(t, err)

--- a/keycloak/client_login_test.go
+++ b/keycloak/client_login_test.go
@@ -34,6 +34,7 @@ func TestLogin(t *testing.T) {
 		Return(nil).
 		AnyTimes()
 
+	mockGetServerInfo(mKeycloak, "22.0.0")
 	mockListGroups(mKeycloak, c, []*gocloak.Group{})
 
 	_, err := c.ListGroups(context.Background())
@@ -64,6 +65,7 @@ func TestLogin_WithLoginRealm(t *testing.T) {
 		Return(nil).
 		AnyTimes()
 
+	mockGetServerInfo(mKeycloak, "22.0.0")
 	mockListGroups(mKeycloak, c, []*gocloak.Group{})
 
 	_, err := c.ListGroups(context.Background())

--- a/keycloak/suite_test.go
+++ b/keycloak/suite_test.go
@@ -3,10 +3,12 @@ package keycloak_test
 import (
 	"strings"
 
+	"github.com/go-resty/resty/v2"
 	. "github.com/vshn/appuio-keycloak-adapter/keycloak"
 
 	gocloak "github.com/Nerzal/gocloak/v13"
 	gomock "github.com/golang/mock/gomock"
+	"github.com/jarcoal/httpmock"
 )
 
 func mockLogin(mgc *MockGoCloak, c Client) {
@@ -32,6 +34,13 @@ func mockListGroups(mgc *MockGoCloak, c Client, groups []*gocloak.Group) {
 		}).
 		Return(groups, nil).
 		Times(1)
+}
+
+func mockKeycloakSubgroups(mgc *MockGoCloak, rst *resty.Client, times int) {
+	mgc.EXPECT().
+		GetRequestWithBearerAuth(gomock.Any(), "token").
+		Return(rst.NewRequest()).
+		Times(times)
 }
 
 func mockGetGroups(mgc *MockGoCloak, c Client, groupName string, groups []*gocloak.Group) {
@@ -147,4 +156,22 @@ func newGocloakGroup(displayName string, id string, path ...string) *gocloak.Gro
 		Path:       gocloak.StringP("/" + strings.Join(path, "/")),
 		Attributes: attributes,
 	}
+}
+
+func setupHttpMock() *resty.Client {
+	rst := resty.New()
+	httpmock.ActivateNonDefault(rst.GetClient())
+	return rst
+}
+
+func setupChildGroupErrorResponse(c Client, groupID string) {
+	httpmock.RegisterResponder("GET", getChildGroupUrl(c.Host, c.Realm, groupID), httpmock.NewStringResponder(404, ""))
+}
+
+func setupChildGroupResponse(c Client, groupID string, childGroups []gocloak.Group) {
+	httpmock.RegisterResponder("GET", getChildGroupUrl(c.Host, c.Realm, groupID), httpmock.NewJsonResponderOrPanic(200, childGroups))
+}
+
+func getChildGroupUrl(host, realm, groupID string) string {
+	return strings.Join([]string{host, "admin", "realms", realm, "groups", groupID, "children"}, "/")
 }

--- a/keycloak/suite_test.go
+++ b/keycloak/suite_test.go
@@ -140,6 +140,17 @@ func mockUpdateUser(mgc *MockGoCloak, c Client, user gocloak.User) {
 		Times(1)
 }
 
+func mockGetServerInfo(mgc *MockGoCloak, version string) {
+	mgc.EXPECT().
+		GetServerInfo(gomock.Any(), "token").
+		Return(&gocloak.ServerInfoRepresentation{
+			SystemInfo: &gocloak.SystemInfoRepresentation{
+				Version: &version,
+			},
+		}, nil).
+		Times(1)
+}
+
 func newGocloakGroup(displayName string, id string, path ...string) *gocloak.Group {
 	if len(path) == 0 {
 		panic("group must have at least one element in path")


### PR DESCRIPTION
## Summary

* `GET /admin/realms/$REALM/groups/$ID` no longer returns the full subgroup-tree
  * Turns out, this doesn't affect us here. We use the `Search` option to always search for a specific group. If the result is a subgroup, the endpoint still returns the full subtree with all parent groups included.
* `GET /admin/realms/$REALM/groups` no longer returns the complete group tree, it now only returns the top level groups
  * This is resolved by querying child groups for each group (similarly to how we already query members for each group), using the new child groups endpoint.
  * If that endpoint doesn't exist (returns a 404), the code does nothing, assuming that we're on an older Keycloak version which would've returned the complete group tree in the first place.
  * Child groups are not queried recursively. This isn't necessary, since we only consider the top 2 levels of groups anyway (any more deeply nested groups are ignored later on).


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
